### PR TITLE
Added config option to specify whether or not to remove the dockerenv and dockerinit files

### DIFF
--- a/pyentrypoint/command.py
+++ b/pyentrypoint/command.py
@@ -99,7 +99,8 @@ class Command(object):
     def run(self):
         if not self.is_handled:
             self._exec()
-        self._rm_dockerenv()
+        if self.config.remove_dockerenv:
+            self._rm_dockerenv()
         if os.getuid() is 0:
             os.setgid(self.config.group)
             os.setuid(self.config.user)

--- a/pyentrypoint/config.py
+++ b/pyentrypoint/config.py
@@ -227,6 +227,13 @@ class Config(ConfigMeta):
         return True
 
     @property
+    def remove_dockerenv(self):
+        """Remove dockerenv and dockerinit files"""
+        if 'remove_dockerenv' in self._config:
+            return bool(self._config['remove_dockerenv'])
+        return True
+
+    @property
     def debug(self):
         """Enable debug logs."""
         if 'ENTRYPOINT_DEBUG' in os.environ:


### PR DESCRIPTION
Added config option to specify whether or not to remove the dockerenv and dockerinit files.

The `self._rm_dockerenv()` operation requires the docker `entrypoint` to be run as the `root` user which is not something I want to do, having the ability to skip this step would be useful. 